### PR TITLE
updating fields that construct the CNM granule uri field

### DIFF
--- a/cumulus_granule_to_cnm/cumulus_granule_to_cnm.py
+++ b/cumulus_granule_to_cnm/cumulus_granule_to_cnm.py
@@ -27,8 +27,8 @@ class GranuleToCNM(Process):
 
         self.logger.debug('provider: {}', meta_provider)
 
-        # Building the URI from info provided by provider since the granule itself might not have it
-        uri = f'{meta_provider["protocol"]}://{meta_provider["host"]}/'
+        # Building the URI protocol from info provided by provider since the granule itself might not have it
+        uri_protocol = f'{meta_provider["protocol"]}://'
 
         cnm_list = []
 
@@ -50,7 +50,7 @@ class GranuleToCNM(Process):
             for file in granule['files']:
                 cnm_granule_file = {
                     'type': file.get('type', '') or '',
-                    'uri': uri + (file.get('path', '')).lstrip('/') + '/' + file.get('name', '') or '',
+                    'uri': uri_protocol + file.get('bucket', '') + '/' + file.get('key', '').lstrip('/') or '',
                     'size': file.get('size', 0) or 0
                 }
                 cnm_files.append(cnm_granule_file)


### PR DESCRIPTION
# Purpose
The ASDC has been testing the granule-to-cnm task as part of an ingest workflow, to notify downstream end users when files have been ingested.  In the course of testing we've noticed that the resulting CNM message returned by this task as being malformed.  This is due to how we've placed this task which happens at the end of an ingest workflow, so inputs into the CNM message are not what is expected.  This PR updates offending fields using standardized Cumulus inputs.

## Standard input to Cumulus tasks
Below is a typical Cumulus-Message-Adapter input which is standard throughout the Cumulus ecosystem.  This input uses https://github.com/nasa/cumulus/blob/master/packages/schemas/files.schema.json for the granule files.

This is the input to granule-to-cnm, which as been passed along a series of previous Cumulus tasks.
#### CMA input to granule-to-cnm
<details>
  <summary>Click to view entire CMA input</summary>

```
{
  "cumulus_meta": {
    "cumulus_version": "21.0.0",
    "execution_name": "1080cae5-1338-4c7f-8ee8-68d3e384307b",
    "message_source": "sfn",
    "queueExecutionLimits": {
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-backgroundJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-backgroundProcessing": 100,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-bignbitJobQueue": 300,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-cissJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-legacyJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-misrReprocessingJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-nonorderableJobQueue": 100,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoNRTIngestJobQueue": 300,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoNRTJobQueue": 300,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoStandardIngestJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoStandardJobQueue": 200
    },
    "sf_event_sqs_to_db_records_types": {},
    "state_machine": "arn:aws:states:us-west-2:868388089840:stateMachine:asdc2-uat-IngestEDOSGranule",
    "system_bucket": "asdc2-uat-internal",
    "workflow_start_time": 1773163898322,
    "parentExecutionArn": "arn:aws:states:us-west-2:868388089840:execution:asdc2-uat-DiscoverEDOSGranules:d2769960-9990-4bdf-83b4-a4eb9c32afd7",
    "queueUrl": "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-backgroundJobQueue"
  },
  "exception": "None",
  "meta": {
    "buckets": {
      "internal": {
        "name": "asdc2-uat-internal",
        "type": "internal"
      },
      "orca_default": {
        "name": "uat-orca-archive",
        "type": "orca"
      },
      "orca_reports": {
        "name": "uat-orca-reports",
        "type": "orca"
      },
      "private": {
        "name": "asdc2-uat-private",
        "type": "private"
      },
      "protected": {
        "name": "asdc2-uat-protected",
        "type": "protected"
      },
      "public": {
        "name": "asdc2-uat-public",
        "type": "public"
      }
    },
    "cmr": {
      "clientId": "IsTqOMMNOS_8-zdNqDuUXA",
      "cmrEnvironment": "UAT",
      "cmrLimit": 100,
      "cmrPageSize": 50,
      "oauthProvider": "launchpad",
      "passwordSecretName": "",
      "provider": "LARC_CLOUD",
      "username": ""
    },
    "collection": {
      "createdAt": 1765562388567,
      "updatedAt": 1771356910584,
      "name": "LIBERA_L0_EDOS",
      "version": "V00",
      "url_path": "LiberaEDOS/{cmrMetadata.CollectionReference.ShortName}.{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime, YYYY.MM.DD)}",
      "duplicateHandling": "replace",
      "granuleId": "^P179\\d{4}[A]{13}.*$",
      "granuleIdExtraction": "^(P179\\d{4}[A]{13}T\\d{13})\\d\\.PDS(|\\.cmr\\.json)$",
      "files": [
        {
          "type": "data",
          "regex": "^P179\\d{4}[A]{13}T\\d{13}1\\.PDS$",
          "bucket": "protected",
          "reportToEms": true,
          "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021401.PDS"
        },
        {
          "type": "metadata",
          "regex": "^P179\\d{4}[A]{13}T\\d{13}0\\.PDS$",
          "bucket": "protected",
          "reportToEms": true,
          "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021400.PDS"
        },
        {
          "type": "metadata",
          "regex": "^P179\\d{4}[A]{13}T\\d{13}1\\.PDS\\.cmr\\.json$",
          "bucket": "private",
          "reportToEms": true,
          "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021401.PDS.cmr.json"
        }
      ],
      "reportToEms": true,
      "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021400.PDS",
      "meta": {
        "generateDMRPP": false,
        "allFilesPresent": true,
        "granuleRecoveryWorkflow": "OrcaRecoveryAdapterWorkflow"
      }
    },
    "distribution_endpoint": "https://data.asdc.uat.earthdata.nasa.gov/",
    "launchpad": {
      "api": "https://api.launchpad.nasa.gov/icam/api/sm/v1",
      "certificate": "launchpad.pfx",
      "passphraseSecretName": "asdc2-uat-message-template-launchpad-passphrase20211118010307989500000006"
    },
    "provider": {
      "id": "S3-Provider",
      "globalConnectionLimit": 1000,
      "host": "asdc2-uat-private",
      "protocol": "s3",
      "createdAt": 1637243246154,
      "updatedAt": 1724434782054
    },
    "stack": "asdc2-uat",
    "template": "s3://asdc2-uat-internal/asdc2-uat/workflow_template.json",
    "workflow_name": "IngestEDOSGranule",
    "workflow_tasks": {
      "0": {
        "name": "asdc2-uat-SyncGranule",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-SyncGranule"
      },
      "1": {
        "name": "asdc2-uat-MoveGranules",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-MoveGranules"
      },
      "2": {
        "name": "asdc2-uat-UpdateGranulesCmrMetadataFileLinks",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-UpdateGranulesCmrMetadataFileLinks"
      },
      "3": {
        "name": "asdc2-uat-OrcaCopyToArchiveAdapter",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-OrcaCopyToArchiveAdapter"
      },
      "4": {
        "name": "asdc2-uat-PostToCmr",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-PostToCmr"
      }
    },
    "input_granules": [
      {
        "granuleId": "P1790011AAAAAAAAAAAAAT2602217365780",
        "dataType": "LIBERA_L0_EDOS",
        "version": "V00",
        "provider": "S3-Provider",
        "files": [
          {
            "size": 432,
            "bucket": "asdc2-uat-protected",
            "key": "LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657800.PDS",
            "source": "libera_edos/P1790011AAAAAAAAAAAAAT26022173657800.PDS",
            "fileName": "P1790011AAAAAAAAAAAAAT26022173657800.PDS",
            "type": "metadata"
          },
          {
            "size": 5059034,
            "bucket": "asdc2-uat-protected",
            "key": "LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS",
            "source": "libera_edos/P1790011AAAAAAAAAAAAAT26022173657801.PDS",
            "fileName": "P1790011AAAAAAAAAAAAAT26022173657801.PDS",
            "type": "data"
          },
          {
            "size": 2298,
            "bucket": "asdc2-uat-private",
            "key": "LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json",
            "source": "libera_edos/P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json",
            "fileName": "P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json",
            "type": "metadata"
          }
        ],
        "sync_granule_duration": 851,
        "createdAt": 1773164672699,
        "cmrLink": "https://cmr.uat.earthdata.nasa.gov/search/concepts/G1280079502-LARC_CLOUD.umm_json",
        "cmrConceptId": "G1280079502-LARC_CLOUD",
        "published": true,
        "cmrMetadataFormat": "umm_json_v1_6_5",
        "post_to_cmr_duration": 898
      }
    ],
    "process": null,
    "sync_granule": {
      "granule_duplicates": {}
    },
    "file_etags": {
      "s3://asdc2-uat-private/LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json": "\"f41906332a8d9fd2fd24f7f8fe141bf4\""
    }
  },
  "payload": {
    "granules": [
      {
        "granuleId": "P1790011AAAAAAAAAAAAAT2602217365780",
        "dataType": "LIBERA_L0_EDOS",
        "version": "V00",
        "provider": "S3-Provider",
        "files": [
          {
            "size": 432,
            "bucket": "asdc2-uat-protected",
            "key": "LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657800.PDS",
            "source": "libera_edos/P1790011AAAAAAAAAAAAAT26022173657800.PDS",
            "fileName": "P1790011AAAAAAAAAAAAAT26022173657800.PDS",
            "type": "metadata"
          },
          {
            "size": 5059034,
            "bucket": "asdc2-uat-protected",
            "key": "LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS",
            "source": "libera_edos/P1790011AAAAAAAAAAAAAT26022173657801.PDS",
            "fileName": "P1790011AAAAAAAAAAAAAT26022173657801.PDS",
            "type": "data"
          },
          {
            "size": 2298,
            "bucket": "asdc2-uat-private",
            "key": "LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json",
            "source": "libera_edos/P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json",
            "fileName": "P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json",
            "type": "metadata"
          }
        ],
        "sync_granule_duration": 851,
        "createdAt": 1773164672699,
        "cmrLink": "https://cmr.uat.earthdata.nasa.gov/search/concepts/G1280079502-LARC_CLOUD.umm_json",
        "cmrConceptId": "G1280079502-LARC_CLOUD",
        "published": true,
        "cmrMetadataFormat": "umm_json_v1_6_5",
        "post_to_cmr_duration": 898
      }
    ]
  },
  "task_config": {
    "bucket": "{$.meta.buckets.internal.name}",
    "stack": "{$.meta.stack}",
    "cmr": "{$.meta.cmr}",
    "launchpad": "{$.meta.launchpad}",
    "etags": "{$.meta.file_etags}",
    "cumulus_message": {
      "outputs": [
        {
          "source": "{$}",
          "destination": "{$.payload}"
        },
        {
          "source": "{$.granules}",
          "destination": "{$.meta.input_granules}"
        }
      ]
    }
  }
}
```
</details>

## Before update behavior
This is the current output to the granule-to-cnm, using the above input.
#### CMA output to granule-to-cnm
<details>
  <summary>Click to view entire CMA output</summary>

```
{
  "cumulus_meta": {
    "cumulus_version": "21.0.0",
    "execution_name": "1080cae5-1338-4c7f-8ee8-68d3e384307b",
    "message_source": "sfn",
    "queueExecutionLimits": {
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-backgroundJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-backgroundProcessing": 100,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-bignbitJobQueue": 300,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-cissJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-legacyJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-misrReprocessingJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-nonorderableJobQueue": 100,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoNRTIngestJobQueue": 300,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoNRTJobQueue": 300,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoStandardIngestJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoStandardJobQueue": 200
    },
    "sf_event_sqs_to_db_records_types": {},
    "state_machine": "arn:aws:states:us-west-2:868388089840:stateMachine:asdc2-uat-IngestEDOSGranule",
    "system_bucket": "asdc2-uat-internal",
    "workflow_start_time": 1773163898322,
    "parentExecutionArn": "arn:aws:states:us-west-2:868388089840:execution:asdc2-uat-DiscoverEDOSGranules:d2769960-9990-4bdf-83b4-a4eb9c32afd7",
    "queueUrl": "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-backgroundJobQueue"
  },
  "exception": "None",
  "meta": {
    "buckets": {
      "internal": {
        "name": "asdc2-uat-internal",
        "type": "internal"
      },
      "orca_default": {
        "name": "uat-orca-archive",
        "type": "orca"
      },
      "orca_reports": {
        "name": "uat-orca-reports",
        "type": "orca"
      },
      "private": {
        "name": "asdc2-uat-private",
        "type": "private"
      },
      "protected": {
        "name": "asdc2-uat-protected",
        "type": "protected"
      },
      "public": {
        "name": "asdc2-uat-public",
        "type": "public"
      }
    },
    "cmr": {
      "clientId": "IsTqOMMNOS_8-zdNqDuUXA",
      "cmrEnvironment": "UAT",
      "cmrLimit": 100,
      "cmrPageSize": 50,
      "oauthProvider": "launchpad",
      "passwordSecretName": "",
      "provider": "LARC_CLOUD",
      "username": ""
    },
    "collection": {
      "createdAt": 1765562388567,
      "updatedAt": 1771356910584,
      "name": "LIBERA_L0_EDOS",
      "version": "V00",
      "url_path": "LiberaEDOS/{cmrMetadata.CollectionReference.ShortName}.{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime, YYYY.MM.DD)}",
      "duplicateHandling": "replace",
      "granuleId": "^P179\\d{4}[A]{13}.*$",
      "granuleIdExtraction": "^(P179\\d{4}[A]{13}T\\d{13})\\d\\.PDS(|\\.cmr\\.json)$",
      "files": [
        {
          "type": "data",
          "regex": "^P179\\d{4}[A]{13}T\\d{13}1\\.PDS$",
          "bucket": "protected",
          "reportToEms": true,
          "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021401.PDS"
        },
        {
          "type": "metadata",
          "regex": "^P179\\d{4}[A]{13}T\\d{13}0\\.PDS$",
          "bucket": "protected",
          "reportToEms": true,
          "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021400.PDS"
        },
        {
          "type": "metadata",
          "regex": "^P179\\d{4}[A]{13}T\\d{13}1\\.PDS\\.cmr\\.json$",
          "bucket": "private",
          "reportToEms": true,
          "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021401.PDS.cmr.json"
        }
      ],
      "reportToEms": true,
      "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021400.PDS",
      "meta": {
        "generateDMRPP": false,
        "allFilesPresent": true,
        "granuleRecoveryWorkflow": "OrcaRecoveryAdapterWorkflow"
      }
    },
    "distribution_endpoint": "https://data.asdc.uat.earthdata.nasa.gov/",
    "launchpad": {
      "api": "https://api.launchpad.nasa.gov/icam/api/sm/v1",
      "certificate": "launchpad.pfx",
      "passphraseSecretName": "asdc2-uat-message-template-launchpad-passphrase20211118010307989500000006"
    },
    "provider": {
      "id": "S3-Provider",
      "globalConnectionLimit": 1000,
      "host": "asdc2-uat-private",
      "protocol": "s3",
      "createdAt": 1637243246154,
      "updatedAt": 1724434782054
    },
    "stack": "asdc2-uat",
    "template": "s3://asdc2-uat-internal/asdc2-uat/workflow_template.json",
    "workflow_name": "IngestEDOSGranule",
    "workflow_tasks": {
      "0": {
        "name": "asdc2-uat-SyncGranule",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-SyncGranule"
      },
      "1": {
        "name": "asdc2-uat-MoveGranules",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-MoveGranules"
      },
      "2": {
        "name": "asdc2-uat-UpdateGranulesCmrMetadataFileLinks",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-UpdateGranulesCmrMetadataFileLinks"
      },
      "3": {
        "name": "asdc2-uat-OrcaCopyToArchiveAdapter",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-OrcaCopyToArchiveAdapter"
      },
      "4": {
        "name": "asdc2-uat-PostToCmr",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-PostToCmr"
      },
      "5": {
        "name": "asdc2-uat-CumulusGranuleToCNM",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-CumulusGranuleToCNM"
      }
    },
    "input_granules": null,
    "process": null,
    "sync_granule": {
      "granule_duplicates": {}
    },
    "file_etags": {
      "s3://asdc2-uat-private/LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json": "\"f41906332a8d9fd2fd24f7f8fe141bf4\""
    }
  },
  "payload": {
    "cnm_list": [
      {
        "version": "1.6.0",
        "provider": "S3-Provider",
        "collection": "LIBERA_L0_EDOS",
        "submissionTime": "2026-03-10T17:48:28.872017Z",
        "identifier": "P1790011AAAAAAAAAAAAAT2602217365780",
        "product": {
          "name": "P1790011AAAAAAAAAAAAAT2602217365780",
          "files": [
            {
              "type": "metadata",
              "uri": "s3://asdc2-uat-private//",
              "size": 432,
              "name": ""
            },
            {
              "type": "data",
              "uri": "s3://asdc2-uat-private//",
              "size": 5059034,
              "name": ""
            },
            {
              "type": "metadata",
              "uri": "s3://asdc2-uat-private//",
              "size": 2298,
              "name": ""
            }
          ],
          "dataVersion": "V00"
        },
        "meta": {
          "source": "arn:aws:states:us-west-2:868388089840:stateMachine:asdc2-uat-IngestEDOSGranule",
          "execution_name": "1080cae5-1338-4c7f-8ee8-68d3e384307b"
        }
      }
    ]
  },
  "task_config": {
    "provider": "{$.meta.provider}",
    "collection": "{$.meta.collection}",
    "cumulus_meta": "{$.cumulus_meta}",
    "provider_path": "{$.meta.provider_path}",
    "cumulus_message": {
      "outputs": [
        {
          "source": "{$}",
          "destination": "{$.payload}"
        },
        {
          "source": "{$.granules}",
          "destination": "{$.meta.input_granules}"
        }
      ]
    }
  }
}
```
</details>

#### Resulting CNM message
The CNM message in the above "before" payload below is incomplete due to field names and use of the `meta.provider`.
```
{
        "version": "1.6.0",
        "provider": "S3-Provider",
        "collection": "LIBERA_L0_EDOS",
        "submissionTime": "2026-03-10T17:48:28.872017Z",
        "identifier": "P1790011AAAAAAAAAAAAAT2602217365780",
        "product": {
          "name": "P1790011AAAAAAAAAAAAAT2602217365780",
          "files": [
            {
              "type": "metadata",
              "uri": "s3://asdc2-uat-private//",
              "size": 432,
              "name": ""
            },
            {
              "type": "data",
              "uri": "s3://asdc2-uat-private//",
              "size": 5059034,
              "name": ""
            },
            {
              "type": "metadata",
              "uri": "s3://asdc2-uat-private//",
              "size": 2298,
              "name": ""
            }
          ],
          "dataVersion": "V00"
        },
        "meta": {
          "source": "arn:aws:states:us-west-2:868388089840:stateMachine:asdc2-uat-IngestEDOSGranule",
          "execution_name": "1080cae5-1338-4c7f-8ee8-68d3e384307b"
        }
      }
```

## After update behavior
This is the modified code's output to the granule-to-cnm, using the same above input.
#### CMA output to granule-to-cnm
<details>
  <summary>Click to view entire CMA output</summary>
```
{
  "cumulus_meta": {
    "cumulus_version": "21.0.0",
    "execution_name": "1080cae5-1338-4c7f-8ee8-68d3e384307b",
    "message_source": "sfn",
    "queueExecutionLimits": {
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-backgroundJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-backgroundProcessing": 100,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-bignbitJobQueue": 300,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-cissJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-legacyJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-misrReprocessingJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-nonorderableJobQueue": 100,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoNRTIngestJobQueue": 300,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoNRTJobQueue": 300,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoStandardIngestJobQueue": 200,
      "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-tempoStandardJobQueue": 200
    },
    "sf_event_sqs_to_db_records_types": {},
    "state_machine": "arn:aws:states:us-west-2:868388089840:stateMachine:asdc2-uat-IngestEDOSGranule",
    "system_bucket": "asdc2-uat-internal",
    "workflow_start_time": 1773163898322,
    "parentExecutionArn": "arn:aws:states:us-west-2:868388089840:execution:asdc2-uat-DiscoverEDOSGranules:d2769960-9990-4bdf-83b4-a4eb9c32afd7",
    "queueUrl": "https://sqs.us-west-2.amazonaws.com/868388089840/asdc2-uat-backgroundJobQueue"
  },
  "exception": "None",
  "meta": {
    "buckets": {
      "internal": {
        "name": "asdc2-uat-internal",
        "type": "internal"
      },
      "orca_default": {
        "name": "uat-orca-archive",
        "type": "orca"
      },
      "orca_reports": {
        "name": "uat-orca-reports",
        "type": "orca"
      },
      "private": {
        "name": "asdc2-uat-private",
        "type": "private"
      },
      "protected": {
        "name": "asdc2-uat-protected",
        "type": "protected"
      },
      "public": {
        "name": "asdc2-uat-public",
        "type": "public"
      }
    },
    "cmr": {
      "clientId": "IsTqOMMNOS_8-zdNqDuUXA",
      "cmrEnvironment": "UAT",
      "cmrLimit": 100,
      "cmrPageSize": 50,
      "oauthProvider": "launchpad",
      "passwordSecretName": "",
      "provider": "LARC_CLOUD",
      "username": ""
    },
    "collection": {
      "createdAt": 1765562388567,
      "updatedAt": 1771356910584,
      "name": "LIBERA_L0_EDOS",
      "version": "V00",
      "url_path": "LiberaEDOS/{cmrMetadata.CollectionReference.ShortName}.{cmrMetadata.CollectionReference.Version}/{dateFormat(cmrMetadata.TemporalExtent.RangeDateTime.BeginningDateTime, YYYY.MM.DD)}",
      "duplicateHandling": "replace",
      "granuleId": "^P179\\d{4}[A]{13}.*$",
      "granuleIdExtraction": "^(P179\\d{4}[A]{13}T\\d{13})\\d\\.PDS(|\\.cmr\\.json)$",
      "files": [
        {
          "type": "data",
          "regex": "^P179\\d{4}[A]{13}T\\d{13}1\\.PDS$",
          "bucket": "protected",
          "reportToEms": true,
          "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021401.PDS"
        },
        {
          "type": "metadata",
          "regex": "^P179\\d{4}[A]{13}T\\d{13}0\\.PDS$",
          "bucket": "protected",
          "reportToEms": true,
          "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021400.PDS"
        },
        {
          "type": "metadata",
          "regex": "^P179\\d{4}[A]{13}T\\d{13}1\\.PDS\\.cmr\\.json$",
          "bucket": "private",
          "reportToEms": true,
          "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021401.PDS.cmr.json"
        }
      ],
      "reportToEms": true,
      "sampleFileName": "P1790147AAAAAAAAAAAAAT16083180021400.PDS",
      "meta": {
        "generateDMRPP": false,
        "allFilesPresent": true,
        "granuleRecoveryWorkflow": "OrcaRecoveryAdapterWorkflow"
      }
    },
    "distribution_endpoint": "https://data.asdc.uat.earthdata.nasa.gov/",
    "launchpad": {
      "api": "https://api.launchpad.nasa.gov/icam/api/sm/v1",
      "certificate": "launchpad.pfx",
      "passphraseSecretName": "asdc2-uat-message-template-launchpad-passphrase20211118010307989500000006"
    },
    "provider": {
      "id": "S3-Provider",
      "globalConnectionLimit": 1000,
      "host": "asdc2-uat-private",
      "protocol": "s3",
      "createdAt": 1637243246154,
      "updatedAt": 1724434782054
    },
    "stack": "asdc2-uat",
    "template": "s3://asdc2-uat-internal/asdc2-uat/workflow_template.json",
    "workflow_name": "IngestEDOSGranule",
    "workflow_tasks": {
      "0": {
        "name": "asdc2-uat-SyncGranule",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-SyncGranule"
      },
      "1": {
        "name": "asdc2-uat-MoveGranules",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-MoveGranules"
      },
      "2": {
        "name": "asdc2-uat-UpdateGranulesCmrMetadataFileLinks",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-UpdateGranulesCmrMetadataFileLinks"
      },
      "3": {
        "name": "asdc2-uat-OrcaCopyToArchiveAdapter",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-OrcaCopyToArchiveAdapter"
      },
      "4": {
        "name": "asdc2-uat-PostToCmr",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-PostToCmr"
      },
      "5": {
        "name": "asdc2-uat-CumulusGranuleToCNM",
        "version": "$LATEST",
        "arn": "arn:aws:lambda:us-west-2:868388089840:function:asdc2-uat-CumulusGranuleToCNM"
      }
    },
    "input_granules": null,
    "process": null,
    "sync_granule": {
      "granule_duplicates": {}
    },
    "file_etags": {
      "s3://asdc2-uat-private/LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json": "\"f41906332a8d9fd2fd24f7f8fe141bf4\""
    }
  },
  "payload": {
    "cnm_list": [
      {
        "version": "1.6.0",
        "provider": "S3-Provider",
        "collection": "LIBERA_L0_EDOS",
        "submissionTime": "2026-03-10T18:00:39.341593Z",
        "identifier": "P1790011AAAAAAAAAAAAAT2602217365780",
        "product": {
          "name": "P1790011AAAAAAAAAAAAAT2602217365780",
          "files": [
            {
              "type": "metadata",
              "uri": "s3://asdc2-uat-protected/LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657800.PDS",
              "size": 432,
              "name": "P1790011AAAAAAAAAAAAAT26022173657800.PDS"
            },
            {
              "type": "data",
              "uri": "s3://asdc2-uat-protected/LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS",
              "size": 5059034,
              "name": "P1790011AAAAAAAAAAAAAT26022173657801.PDS"
            },
            {
              "type": "metadata",
              "uri": "s3://asdc2-uat-private/LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json",
              "size": 2298,
              "name": "P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json"
            }
          ],
          "dataVersion": "V00"
        },
        "meta": {
          "source": "arn:aws:states:us-west-2:868388089840:stateMachine:asdc2-uat-IngestEDOSGranule",
          "execution_name": "1080cae5-1338-4c7f-8ee8-68d3e384307b"
        }
      }
    ]
  },
  "task_config": {
    "provider": "{$.meta.provider}",
    "collection": "{$.meta.collection}",
    "cumulus_meta": "{$.cumulus_meta}",
    "provider_path": "{$.meta.provider_path}",
    "cumulus_message": {
      "outputs": [
        {
          "source": "{$}",
          "destination": "{$.payload}"
        },
        {
          "source": "{$.granules}",
          "destination": "{$.meta.input_granules}"
        }
      ]
    }
  }
}
```
</details>

#### Resulting CNM message
Correct inputs to the CMA with code updates.

```
{
        "version": "1.6.0",
        "provider": "S3-Provider",
        "collection": "LIBERA_L0_EDOS",
        "submissionTime": "2026-03-10T18:00:39.341593Z",
        "identifier": "P1790011AAAAAAAAAAAAAT2602217365780",
        "product": {
          "name": "P1790011AAAAAAAAAAAAAT2602217365780",
          "files": [
            {
              "type": "metadata",
              "uri": "s3://asdc2-uat-protected/LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657800.PDS",
              "size": 432,
              "name": "P1790011AAAAAAAAAAAAAT26022173657800.PDS"
            },
            {
              "type": "data",
              "uri": "s3://asdc2-uat-protected/LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS",
              "size": 5059034,
              "name": "P1790011AAAAAAAAAAAAAT26022173657801.PDS"
            },
            {
              "type": "metadata",
              "uri": "s3://asdc2-uat-private/LiberaEDOS/LIBERA_L0_EDOS.V00/2025.08.19/P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json",
              "size": 2298,
              "name": "P1790011AAAAAAAAAAAAAT26022173657801.PDS.cmr.json"
            }
          ],
          "dataVersion": "V00"
        },
        "meta": {
          "source": "arn:aws:states:us-west-2:868388089840:stateMachine:asdc2-uat-IngestEDOSGranule",
          "execution_name": "1080cae5-1338-4c7f-8ee8-68d3e384307b"
        }
      }
      ```